### PR TITLE
BDOG-2378 Replace any NonceAttr placeholder

### DIFF
--- a/src/main/scala/uk/gov/hmrc/webchat/internal/WebChatClientImpl.scala
+++ b/src/main/scala/uk/gov/hmrc/webchat/internal/WebChatClientImpl.scala
@@ -26,24 +26,22 @@ import uk.gov.hmrc.webchat.repositories.CacheRepository
 class WebChatClientImpl @Inject()(cacheRepository: CacheRepository,
                                   webChatConfig: WebChatConfig)
   extends WebChatClient {
-  def loadRequiredElements()(implicit request: Request[_]): Option[Html] = {
-    getPartial (() => cacheRepository.getRequiredPartial())
-  }
+  def loadRequiredElements()(implicit request: Request[_]): Option[Html] =
+    getPartial(() => cacheRepository.getRequiredPartial())
 
-  def loadHMRCChatSkinElement(partialType: String)(implicit request: Request[_]): Option[Html] = {
-    getPartial (() => cacheRepository.getHMRCChatSkinPartial(partialType))
-  }
+  def loadHMRCChatSkinElement(partialType: String)(implicit request: Request[_]): Option[Html] =
+    getPartial(() => cacheRepository.getHMRCChatSkinPartial(partialType))
 
-  def loadWebChatContainer(id: String = "HMRC_Fixed_1")(implicit request: Request[_]) : Option[Html] = {
-    getPartial (() => cacheRepository.getContainerPartial(id))
-  }
+  def loadWebChatContainer(id: String = "HMRC_Fixed_1")(implicit request: Request[_]): Option[Html] =
+    getPartial(() => cacheRepository.getContainerPartial(id))
 
-  private def getPartial(get: () => Html): Option[Html] = {
+  private def getPartial(get: () => Html)(implicit request: Request[_]): Option[Html] =
     if (webChatConfig.enabled) {
       val result = get()
-      if (result.body.isEmpty) None else Some(result)
-    } else {
+      if (result.body.isEmpty)
+        None
+      else
+        Some(Html(result.body.replace("{{NONCE_ATTR}}", views.html.helper.CSPNonce.attr.body)))
+    } else
       None
-    }
-  }
 }


### PR DESCRIPTION
# BDOG-2378

This change supports the enablement of nonce CSP.

Any NONCE_ATTR placeholder in the returned HTML will be replaced with the clients nonce (or blank if `play.filters.csp..CSPFilter` has not been enabled).

## Checklist PR Raiser
 - [ ]  I've ensured code coverage has not decreased
 - [ ]  I've dealt with any new compilation warnings
 - [ ]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge