### PR TITLE
DEP-7033 Adding new div elements into the HMRCPopupView, and dropping Play 2.9 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,6 @@ import sbt.Keys.sourceDirectories
 
 val appName = "digital-engagement-platform-chat"
 
-val scala2_12 = "2.12.15"
 val scala2_13 = "2.13.16"
 val scala3 = "3.3.5"
 
@@ -13,9 +12,6 @@ ThisBuild / isPublicArtefact   := true
 
 lazy val library = (project in file("."))
   .settings(publish / skip := true)
-  .settings(
-    resolvers += Resolver.jcenterRepo
-  )
   .aggregate(
     play30
   )

--- a/build.sbt
+++ b/build.sbt
@@ -17,17 +17,7 @@ lazy val library = (project in file("."))
     resolvers += Resolver.jcenterRepo
   )
   .aggregate(
-    play29,
     play30
-  )
-
-lazy val play29 = Project("digital-engagement-platform-chat-29", file("play-29"))
-  .enablePlugins(SbtTwirl, RoutesCompiler, BuildInfoPlugin)
-  .settings(
-    crossScalaVersions := Seq(scala2_13),
-    libraryDependencies ++= AppDependencies.play29 ++ AppDependencies.play29Test ++ AppDependencies.test,
-    Compile / TwirlKeys.compileTemplates / sourceDirectories += baseDirectory.value / s"src/main/twirl",
-    TwirlKeys.constructorAnnotations += "@javax.inject.Inject()"
   )
 
 lazy val play30 = Project("digital-engagement-platform-chat-30", file("play-30"))

--- a/play-29/src/main/scala/uk/gov/hmrc/webchat/client/WebChatClient.scala
+++ b/play-29/src/main/scala/uk/gov/hmrc/webchat/client/WebChatClient.scala
@@ -36,13 +36,13 @@ class WebChatClient @Inject()(nuanceEncryptionService: NuanceEncryptionService,
   def loadRequiredElements()(implicit request: Request[_]): Option[Html] = {
     Some(withCSPNonce(requiredElements(encryptedNuanceData)))
   }
-  def loadHMRCChatSkinElement(partialType: String)(implicit request: Request[_]): Option[Html] = {
+  def loadHMRCChatSkinElement(partialType: String, id: String = "")(implicit request: Request[_]): Option[Html] = {
     partialType match {
-      case "popup" => Some(withCSPNonce(popupChatSkinElement()))
+      case "popup" => Some(withCSPNonce(popupChatSkinElement(id)))
       case "embedded" => Some(withCSPNonce(embeddedChatSkinElement()))
       case partialType =>
         logger.warn(s"invalid partial type '$partialType' passed to loadHMRCChatSkinElement, defaulting to popup")
-       Some(withCSPNonce(popupChatSkinElement()))
+       Some(withCSPNonce(popupChatSkinElement(id)))
     }
   }
   def loadWebChatContainer(id: String = "HMRC_Fixed_1")(implicit request: Request[_]) : Option[Html] = {

--- a/play-29/src/main/twirl/uk/gov/hmrc/webchat/views/HMRCPopupView.scala.html
+++ b/play-29/src/main/twirl/uk/gov/hmrc/webchat/views/HMRCPopupView.scala.html
@@ -19,8 +19,10 @@
 
 @this(appConfig: WebChatConfig)
 
-@()(implicit request: RequestHeader)
+@(id : String = "")(implicit request: RequestHeader)
 
 <script {{NONCE_ATTR}} language="javascript" id="hmrc-webchat-tag" src=@{appConfig.hmrcSkinJSUrl}></script>
 <link {{NONCE_ATTR}} rel="stylesheet" href='@{appConfig.hmrcSkinPopupCSSUrl}' type="text/css">
 <div id="tc-nuance-chat-container"></div>
+<div id="dav4"></div>
+<div id="@id"></div>

--- a/play-30/src/main/scala/uk/gov/hmrc/webchat/client/WebChatClient.scala
+++ b/play-30/src/main/scala/uk/gov/hmrc/webchat/client/WebChatClient.scala
@@ -36,13 +36,13 @@ class WebChatClient @Inject()(nuanceEncryptionService: NuanceEncryptionService,
   def loadRequiredElements()(implicit request: Request[_]): Option[Html] = {
     Some(withCSPNonce(requiredElements(encryptedNuanceData)))
   }
-  def loadHMRCChatSkinElement(partialType: String)(implicit request: Request[_]): Option[Html] = {
+  def loadHMRCChatSkinElement(partialType: String, id: String = "")(implicit request: Request[_]): Option[Html] = {
     partialType match {
-      case "popup" => Some(withCSPNonce(popupChatSkinElement()))
+      case "popup" => Some(withCSPNonce(popupChatSkinElement(id)))
       case "embedded" => Some(withCSPNonce(embeddedChatSkinElement()))
       case partialType =>
         logger.warn(s"invalid partial type '$partialType' passed to loadHMRCChatSkinElement, defaulting to popup")
-       Some(withCSPNonce(popupChatSkinElement()))
+       Some(withCSPNonce(popupChatSkinElement(id)))
     }
   }
   def loadWebChatContainer(id: String = "HMRC_Fixed_1")(implicit request: Request[_]) : Option[Html] = {

--- a/play-30/src/main/twirl/uk/gov/hmrc/webchat/views/HMRCPopupView.scala.html
+++ b/play-30/src/main/twirl/uk/gov/hmrc/webchat/views/HMRCPopupView.scala.html
@@ -19,8 +19,10 @@
 
 @this(appConfig: WebChatConfig)
 
-@()(implicit request: RequestHeader)
+@(id : String = "")(implicit request: RequestHeader)
 
 <script {{NONCE_ATTR}} language="javascript" id="hmrc-webchat-tag" src=@{appConfig.hmrcSkinJSUrl}></script>
 <link {{NONCE_ATTR}} rel="stylesheet" href='@{appConfig.hmrcSkinPopupCSSUrl}' type="text/css">
 <div id="tc-nuance-chat-container"></div>
+<div id="dav4"></div>
+<div id="@id"></div>

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,26 +1,17 @@
 import sbt._
 
 object AppDependencies {
-  val play29 = Seq(
-    "uk.gov.hmrc" %% "play-partials-play-29"    % "10.0.0",
-    "uk.gov.hmrc" %% "bootstrap-common-play-29" % "9.11.0"
-  )
-
-  val play29Test = Seq(
-    "uk.gov.hmrc"           %% "bootstrap-test-play-29"   % "9.11.0"   % "test"
-  )
 
   val play30 = Seq(
-    "uk.gov.hmrc" %% "play-partials-play-30"    % "10.0.0",
-    "uk.gov.hmrc" %% "bootstrap-common-play-30" % "9.11.0"
+    "uk.gov.hmrc" %% "play-partials-play-30"    % "10.1.0",
+    "uk.gov.hmrc" %% "bootstrap-common-play-30" % "9.14.0"
   )
 
   val play30Test = Seq(
-    "uk.gov.hmrc"           %% "bootstrap-test-play-30"   % "9.11.0"   % "test"
+    "uk.gov.hmrc"           %% "bootstrap-test-play-30"   % "9.14.0"   % "test"
   )
 
   lazy val test: Seq[ModuleID] = Seq(
-    "org.pegdown"           %  "pegdown"                  % "1.6.0"   % "test",
     "org.scalatest"         %% "scalatest"                % "3.2.12"  % "test",
     "org.mockito"           %  "mockito-core"             % "4.5.1"   % "test",
     "com.vladsch.flexmark"  % "flexmark-all"              % "0.62.2"  % "test",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
 
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.8")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.6")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
 


### PR DESCRIPTION
# DEP-7033

- Adding two new div elements into HMRCPopupView, with ids 'dav4' and 'id'. 
- The 'dav4' div is to show that the chatskin is a dav4 (i.e., a popup and HMRC styling). The 'id' div is to be used as an identifier for the chat. 'id' is a parameter that can be passed into the method through WebChatClient (default of ""). This is done because for HMRCPopupView, there is currently no 'id' that can be used to identify the chatskin (like there is for 'NuanceTagElementView'). 
- Dropping support for Play 2.9, as this is no longer being used for this library. 
- Resolving platops pr bot comments.

## Checklist PR Raiser
 - [ ]  I've ensured code coverage has not decreased
 - [ ]  I've dealt with any new compilation warnings
 - [ ]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge